### PR TITLE
Remove mailboxIdentifier from CreateMailbox request

### DIFF
--- a/draft-secure-credential-transfer.md
+++ b/draft-secure-credential-transfer.md
@@ -277,7 +277,7 @@ Value is defined as a combination of the following values: "R" - for read access
 {: #apple-push-token title="Apple Push Token Example"}
 
 ~~~
-{    "mailboxIdentifier" : "12345678-9...A-BCD",
+{
     "displayInformation" : {
         "title" : "Hotel Pass",
         "description" : "Some Hotel Pass",


### PR DESCRIPTION
Relay server will be generating the mailboxIdentifier and no longer needs to be provided inside the CreateMailbox request body. Remove from example.