### PR TITLE
Added two sentences to charter document further highlighting that no …

### DIFF
--- a/charter.md
+++ b/charter.md
@@ -2,7 +2,7 @@
 
 There are many situations in which it is desirable to share a digital credential with another person. For example, you may want to provide access to your vehicle to a friend or a family member. You may also want to provide access to your home to your cat sitter. Or, you may want to share a hotel key with your spouse. Today, no such standardized method exists in a cross-platform, multidisciplinary capacity. 
 
-The WG charter includes the definition and standardization of a protocol that will facilitate such credential transfers from individual to individual. The protocol will leverage a “relay server” to transfer data from sender to recipient. The scope of the transfer is limited to a single origin device and a single destination device.
+The WG charter includes the definition and standardization of a protocol that will facilitate such credential transfers from individual to individual. The protocol will leverage a “relay server” to transfer data from sender to recipient. The scope of the transfer is limited to a single origin device and a single destination device. Note that neither private keys nor secret symmetric keys present on the sender's device are exchanged during the transfer operation. In the transfer protocol, the "credential" being sent from sender to recipient comprises data both necessary and sufficient for the recipient to exchange with the credential authority for new digital key material granting the recipient a subset of the sender's capabilities or entitlements.
 
 Privacy goals include:
 


### PR DESCRIPTION
Added two sentences to charter document further highlighting that no key material is actually transffered. Making this commit primarily to address Michael's feedback from the SECRET email distribution."
[charter-clarification-feb22 19b5b2c] Added two sentences to charter document further highlighting that no key material is actually transffered. Making this commit primarily to address Michael's feedback from the SECRET email distribution.