### PR TITLE
Update draft-secure-credential-transfer.md

### DIFF
--- a/draft-secure-credential-transfer.md
+++ b/draft-secure-credential-transfer.md
@@ -725,6 +725,8 @@ The following threats and mitigations have been considered:
       URLs displayed to user SHOULD include the https scheme.
     - MailboxIdentifier guessing:
       the MailboxIdentifier is a version 4 UUID {{!RFC4122}} which SHOULD contain 122-bits of cryptographic entropy, making brute-force attacks impractical
+- Risk of hosting malicious or untrusted scripts by relay server preview page (ReadDisplayInformationFromMailbox) 
+    - Relay server should either not allow hosting a third party JavaScripts on a preview page or implement a policy and utilize tools to maintain the trust of such scripts (e.g. force client to verify the script against a good known hash of it).   
 
 ## Sender/Receiver privacy
 


### PR DESCRIPTION
Addressing concern of hosting untrusted JS on Relay server display information landing page